### PR TITLE
[fix] 메인페이지 섹션별 버그 수정 (1)

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,9 +1,8 @@
 import { ReactNode } from 'react';
 
 import Navbar from '@components/Navbar';
-import SearchwordSection from '@pages/Home/SearchwordSection';
+import Footer from './Footer';
 
-// import Footer from './Footer';
 interface MainLayoutProps {
   children?: ReactNode;
 }
@@ -11,11 +10,11 @@ interface MainLayoutProps {
 const MainLayout = ({ children }: MainLayoutProps) => {
   return (
     <>
-
-      <Navbar />    
+      <Navbar />
       <main className="xl:max-w-[1920px] lg:max-w-[1024px] sm:max-w-[390px] mx-auto">
         {children}
       </main>
+      <Footer />
     </>
   );
 };

--- a/src/pages/Home/HeroSection.tsx
+++ b/src/pages/Home/HeroSection.tsx
@@ -17,15 +17,15 @@ const HeroSection = () => {
   return (
     <Section
       as="section"
-      className=" w-full relative
-        xl:mx-[16.25rem] lg:mx-[1.875rem] sm:mx-[1.125rem]
+      className="relative
+        xl:px-0 lg:px-[1.875rem] sm:px-[1.125rem]
         xl:mb-60 lg:mb-40 sm:mb-32"
     >
       <div
         className="absolute
-          xl:-left-[10.325rem] xl:-bottom-[2rem]
-          lg:right-5 lg:-bottom-5
-          sm:right-8 sm:-bottom-0
+          xl:left-[4.25rem] xl:-bottom-[2.75rem]
+          lg:right-5 lg:bottom-2
+          sm:right-2 sm:bottom-0
           cursor-default"
       >
         <span className="inline-block -rotate-90 absolute top-4 -left-7">
@@ -33,7 +33,10 @@ const HeroSection = () => {
         </span>
         <ScrollArrow className="lg:h-auto sm:h-[100px] rotate-180" />
       </div>
-      <div className="relative lg:w-auto sm:min-w-[440px] xl:pt-[23.25rem] lg:pt-[12rem]">
+      <div
+        className="relative lg:w-auto sm:min-w-[440px]
+          xl:pl-[16.25rem] xl:pt-[23.25rem] lg:pt-[12rem]"
+      >
         <Slide duration={3000}>
           {({ index, changeIndex }) => (
             <>
@@ -44,7 +47,7 @@ const HeroSection = () => {
                     ${index === bgIndex ? 'opacity-100' : 'opacity-0'}
                     xl:w-[1338px] lg:w-[785px] sm:w-[440px]
                     absolute transition ${ANIMATION_DURATION}
-                    xl:-top-[23rem] xl:left-[15.625rem]
+                    xl:-top-[23rem] xl:left-[31.875rem]
                     lg:-top-[10rem] lg:-right-[5.375rem]
                     sm:top-[0.875rem] sm:-right-[1.5rem]
                     -z-50

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -5,19 +5,16 @@ import RecruitSection from './RecruitSection';
 import HeroSection from './HeroSection';
 import CommunitySection from './CommunitySection';
 
-
 const Home: React.FC = () => {
   return (
     <div>
-      <SearchwordSection />
       <HeroSection />
+      <SearchwordSection />
       <CommunitySection />
       <RecruitSection />
       <NoticeSection />
-      <SearchwordSection />;
     </div>
   );
-
 };
 
 export default Home;

--- a/src/pages/Home/NoticeSection.tsx
+++ b/src/pages/Home/NoticeSection.tsx
@@ -31,20 +31,21 @@ const NoticeCard = ({
 }: NoticeCardProps) => {
   return (
     <Link key={id} to={src} className="w-fit">
-      <li className="group xl:w-[18.125rem] lg:w-[12.5rem] sm:w-[9rem] relative">
+      <li className="group xl:w-[14vw] lg:w-[12.5rem] sm:w-[9rem] relative">
         <p className="mb-5 xl:text-lg lg:text-[0.875rem] sm:text-[0.625rem]">
           {id}
         </p>
         <p
-          className="mb-4 xl:text-4xl lg:text-[1.625rem] sm:text-lg
+          className="xl:text-[1.8vw] lg:text-[1.625rem] sm:text-lg
+            xl:leading-[2vw]
             xl:mb-5 lg:mb-4 sm:mb-2.5 font-bold line-clamp-1"
         >
           {title}
         </p>
         <p
-          className="mb-[1.875rem] lg:mb-8 sm:mb-[1.125rem]
-            xl:text-xl lg:text-[0.875rem] sm:text-[0.625rem] 
-            xl:leading-9 lg:leading-[1.625rem] line-clamp-2 break-keep"
+          className="mb-[1.5vw] lg:mb-8 sm:mb-[1.125rem]
+            xl:text-[0.975vw] lg:text-[0.875rem] sm:text-[0.625rem] 
+            xl:leading-[1.75vw] lg:leading-[1.625rem] line-clamp-2 break-keep"
         >
           {content}
         </p>
@@ -76,7 +77,7 @@ const NoticeSection = () => {
         flex flex-col
         xl:items-stretch sm:items-center
         xl:px-[16.25rem] lg:px-[1.875rem]
-        py-32"
+        py-32 mb-[5rem]"
     >
       <div className="flex items-center xl:justify-between justify-center xl:mb-5 lg:mb-[3.75rem] sm:mb-[2.25rem]">
         <div>
@@ -96,9 +97,10 @@ const NoticeSection = () => {
       </div>
       <ul
         className="lg:w-full sm:w-72
-          flex flex-wrap
+          flex
           lg:justify-normal sm:justify-center
-          xl:gap-[5rem] lg:gap-[3.125rem] sm:[1.875rem]"
+          xl:gap-[5rem] lg:gap-[3.125rem] sm:[1.875rem]
+          xl:text-lg"
       >
         {DATA.map((data) => (
           <NoticeCard key={data.id} {...data} />

--- a/src/pages/Home/RecruitSection.tsx
+++ b/src/pages/Home/RecruitSection.tsx
@@ -84,7 +84,7 @@ const RecruitSection = () => {
         xl:mb-40 lg:mb-32 sm:mb-20"
     >
       <div
-        className="xl:flex-none lg:flex-1
+        className="lg:flex-1
           xl:w-[25rem] xl:text-left sm:text-center xl:mb-0 lg:mb-10"
       >
         <div

--- a/src/pages/Home/SearchwordSection.tsx
+++ b/src/pages/Home/SearchwordSection.tsx
@@ -5,7 +5,7 @@ import { MOCK_DATA } from '@data/Search';
 import RenderItems from '@data/Render';
 import ChevronButton from '@components/ChevronButton';
 
-import Zoom from '@assets/img/zoom.svg';
+import Zoom from '@assets/img/zoom.svg?react';
 
 const SearchwordSection = () => {
   const [activeItem, setActiveItem] = useState(1);
@@ -91,12 +91,9 @@ const SearchwordSection = () => {
               <button
                 onClick={handleZoomButonClick}
                 className="absolute right-[1.25rem]"
+                aria-label="링크 아이콘"
               >
-                <img
-                  src={Zoom}
-                  alt="링크 아이콘"
-                  className="rounded-full h-20 ml-14 xl:-translate-y-1 lg:-translate-y-9 sm:-translate-y-6 xl:w-[4rem] lg:w-[3.75rem] sm:w-[1.875rem]"
-                />
+                <Zoom className="rounded-full h-20 ml-14 xl:-translate-y-1 lg:-translate-y-9 sm:-translate-y-6 xl:w-[4rem] lg:w-[3.75rem] sm:w-[1.875rem]" />
               </button>
             )}
           </li>

--- a/src/pages/Home/SearchwordSection.tsx
+++ b/src/pages/Home/SearchwordSection.tsx
@@ -1,9 +1,11 @@
-import Section from '@layouts/Section';
 import { useState, useEffect } from 'react';
-import Zoom from '@assets/img/zoom.svg';
+
+import Section from '@layouts/Section';
+import { MOCK_DATA } from '@data/Search';
+import RenderItems from '@data/Render';
 import ChevronButton from '@components/ChevronButton';
-import { MOCK_DATA } from 'src/data/Search';
-import RenderItems from 'src/data/Render';
+
+import Zoom from '@assets/img/zoom.svg';
 
 const SearchwordSection = () => {
   const [activeItem, setActiveItem] = useState(1);
@@ -11,10 +13,9 @@ const SearchwordSection = () => {
   const TOTAL_ITEMS = MOCK_DATA.length;
   const VISIBLE_ITEMS_COUNT = 5;
 
-
   useEffect(() => {
     const intervalId = setInterval(() => {
-      setActiveItem((prevItem) => (prevItem % totalItems) + 1);
+      setActiveItem((prevItem) => (prevItem % TOTAL_ITEMS) + 1);
       setIsZoom(true);
     }, 3000);
 
@@ -27,13 +28,11 @@ const SearchwordSection = () => {
 
   const handlePrevButtonClick = () => {
     setActiveItem((prevItem) => (prevItem === 1 ? TOTAL_ITEMS : prevItem - 1));
-
   };
 
   const handleZoomButonClick = () => {
     setIsZoom(true);
   };
-
 
   const items = RenderItems(activeItem, VISIBLE_ITEMS_COUNT, TOTAL_ITEMS);
 
@@ -43,7 +42,7 @@ const SearchwordSection = () => {
       className="w-full flex xl:flex-row sm:flex-col
         xl:items-center sm:items-center
         xl:px-[16.25rem] lg:mx-w-[80rem] sm:mx-w-[24.375rem]
-         py-[6.25rem]
+        py-[6.25rem]
         xl:mb-40 lg:mb-32 sm:mb-20"
     >
       <div className="flex flex-col justify-center items-center min-w-[25rem]">


### PR DESCRIPTION
# Pull Request 요약

> PR에 대한 내용을 작성해주세요.

1. `SearchwordSection` 컴포넌트의 `totalItems` 변수를 참조할 수 없습니다.
2. `SearchwordSection` 컴포넌트에서 리렌더링이 발생할 때마다 `zoom.svg`가 재다운로드 됩니다.
3. `RecruitSection` 컴포넌트의 너비가 조금 좁습니다.
4. `NoticeSection` 컴포넌트의 데스크탑 반응형을 적용해야 합니다.
5. `HeroSection` 컴포넌트에서 가로 스크롤이 발생합니다.

<br>

## 작업 내용

> 작업 내용에 대해서 작성해주세요.

1. 18번 라인 `totalItems` -> `TOTAL_ITEMS` 변경
2. `zoom.svg` `import`를 리액트 컴포넌트 `import`로 변경
3. `flex-none` 속성을 삭제하여 좌우 여백의 너비의 균형을 맞추었습니다.
4. 데스크탑 반응형 적용
5. CSS Style 수정하여 가로 스크롤이 발생하지 않도록 했습니다.

<br>

## 참고 사항

> 참고 사항이 있다면 첨부해주세요.

1. 
![code](https://github.com/yourteacher-org/yourteacher-fe/assets/59536977/fb9d96a0-44d1-4bdd-a85d-ea73e981c134)

2. 
![code](https://github.com/yourteacher-org/yourteacher-fe/assets/59536977/2af5eb38-5870-4939-823b-a97848221e58)

3. 
<img width="2056" alt="image" src="https://github.com/yourteacher-org/yourteacher-fe/assets/59536977/3b3a819c-afaa-4e9b-9fa7-f607588afcaf">

4. 
![CleanShot 2024-03-27 at 11 56 16](https://github.com/yourteacher-org/yourteacher-fe/assets/59536977/cfafe185-84bf-4eaa-9d9b-6d22b44f67d5)

5.
![CleanShot 2024-03-27 at 11 56 54](https://github.com/yourteacher-org/yourteacher-fe/assets/59536977/42d83b61-51ef-40b2-a5fa-dbcb4784f3a5)


<br>

## 관련 이슈

> closing할 이슈 번호를 작성해주세요.

- Close #34 

<br>
